### PR TITLE
Updated to "key" instead of ID.

### DIFF
--- a/credentials/MastodonOAuth2Api.credentials.ts
+++ b/credentials/MastodonOAuth2Api.credentials.ts
@@ -34,7 +34,7 @@ export class MastodonOAuth2Api implements ICredentialType {
 			required: true,
 		},
 		{
-			displayName: 'Client ID',
+			displayName: 'Client Key',
 			name: 'clientId',
 			type: 'string',
 			default: '',


### PR DESCRIPTION
From what i can tell mastodon doesn't call it key, but ID.