### PR TITLE
Add support for setting the status visibility

### DIFF
--- a/nodes/Mastodon/Mastodon_Methods.ts
+++ b/nodes/Mastodon/Mastodon_Methods.ts
@@ -67,6 +67,10 @@ export const methods = {
 			body.language = additionalFields.language as string;
 		}
 
+		if (additionalFields.visibility) {
+			body.visibility = additionalFields.visibility as string;
+		}
+
 		if (additionalFields.attachments) {
 			const attachments = additionalFields.attachments as string;
 

--- a/nodes/Mastodon/Mastodon_Properties.ts
+++ b/nodes/Mastodon/Mastodon_Properties.ts
@@ -144,6 +144,13 @@ export const properties = {
 					default: '',
 					description: 'The language of the status update',
 				},
+				{
+					displayName: 'Visibility',
+					name: 'visibility',
+					type: 'string',
+					default: 'public',
+					description: 'Visibility of this status (one of: public, unlisted, private, direct)',
+				},
 			],
 		} as INodeProperties,
 	],

--- a/nodes/Mastodon/StatusInterface.ts
+++ b/nodes/Mastodon/StatusInterface.ts
@@ -5,4 +5,5 @@ export interface IStatus {
 	in_reply_to_id?: string;
 	spoiler_text?: string;
 	language?: string;
+	visibility?: string;
 }


### PR DESCRIPTION
Please add support for setting the visibility of the post.

I just gave it a try and started to adapt the code accordingly (based on my understanding of how it works).
However, I'm a JS/TS noob and I've also no experience with creating own n8n nodes.

Please review and give hints if there's anything else that needs to be changed or added.
Would love to see it merged and released soon.