### PR TITLE
Add read scope by default

### DIFF
--- a/credentials/MastodonOAuth2Api.credentials.ts
+++ b/credentials/MastodonOAuth2Api.credentials.ts
@@ -1,5 +1,10 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
+const scopes = [
+	'read',
+	'write',
+];
+
 export class MastodonOAuth2Api implements ICredentialType {
 	name = 'mastodonOAuth2Api';
 	extends = ['oAuth2Api'];
@@ -55,8 +60,8 @@ export class MastodonOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'string',
-			default: 'write',
+			type: 'hidden',
+			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',


### PR DESCRIPTION
Hid the scope field, as editing it, doesn't seem to yield the correct result and it's how scopes have been implemented for most credentials

If you check the [built-in OAuth credentials](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/credentials) they all have the scope hidden field, except the generic OAuthApi credential. 
Seems to me, that editing the scope isn't really supported. Changing the default to use both `read` and `write` however seems to work. You may need to clear the cache, otherwise it may just reuse the previous default still.

Fixes #13